### PR TITLE
Refactor front-end app interactions

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -1272,10 +1272,17 @@ input[type="range"]::-webkit-slider-thumb {
     font-size: 28px;
     font-weight: bold;
     cursor: pointer;
+    background: none;
+    border: none;
 }
 
 .close:hover {
     color: #ff6b35;
+}
+
+.close:focus {
+    outline: 2px solid #ff6b35;
+    outline-offset: 2px;
 }
 
 .modal-content h3 {
@@ -1285,6 +1292,20 @@ input[type="range"]::-webkit-slider-thumb {
 
 .modal-content form {
     margin: 2rem 0;
+}
+
+.form-feedback {
+    margin-top: 0.75rem;
+    font-size: 0.95rem;
+    min-height: 1.4rem;
+}
+
+.form-feedback--success {
+    color: #0a8f3a;
+}
+
+.form-feedback--error {
+    color: #d8343a;
 }
 
 .modal-content input {

--- a/assets/main.js
+++ b/assets/main.js
@@ -508,9 +508,13 @@ const App = {
         }
 
         let remaining = this.config.callbackSeconds;
-        this.elements.timerIdle?.style.display = 'none';
+        if (this.elements.timerIdle) {
+            this.elements.timerIdle.style.display = 'none';
+        }
         this.elements.timerActive.style.display = 'block';
-        this.elements.timerFinished?.style.display = 'none';
+        if (this.elements.timerFinished) {
+            this.elements.timerFinished.style.display = 'none';
+        }
         this.elements.callbackCountdown.textContent = String(remaining);
 
         if (this.elements.timerProgress) {
@@ -539,8 +543,12 @@ const App = {
             this.state.callbackInterval = null;
         }
 
-        this.elements.timerActive?.style.display = 'none';
-        this.elements.timerFinished?.style.display = 'block';
+        if (this.elements.timerActive) {
+            this.elements.timerActive.style.display = 'none';
+        }
+        if (this.elements.timerFinished) {
+            this.elements.timerFinished.style.display = 'block';
+        }
     },
 
     callAnalytics(goal) {

--- a/index.html
+++ b/index.html
@@ -52,11 +52,11 @@
                         <i class="fas fa-phone"></i>
                         +7 (977) 295-71-71
                     </a>
-                    <div class="mobile-menu-toggle" onclick="toggleMobileMenu()">
+                    <button class="mobile-menu-toggle" type="button" aria-label="Открыть меню" aria-expanded="false" aria-controls="navMenu">
                         <span></span>
                         <span></span>
                         <span></span>
-                    </div>
+                    </button>
                 </div>
             </div>
         </div>
@@ -75,7 +75,7 @@
                             <i class="fas fa-phone"></i>
                             ВЫЗВАТЬ СЕЙЧАС
                         </a>
-                        <button class="btn btn-secondary" onclick="ym(103201010,'reachGoal','tel_click'); openCallbackModal()">
+                        <button class="btn btn-secondary" data-modal="callback" data-ym-goal="tel_click">
                             <i class="fas fa-callback"></i>
                             ПЕРЕЗВОНИТЬ МНЕ
                         </button>
@@ -192,14 +192,14 @@
 
                 <div class="form-group">
                     <label>
-                        <input type="checkbox" id="expressService" onchange="calculateAdvancedPrice()">
+                        <input type="checkbox" id="expressService">
                         Экспресс-подача (до 15 минут) +500₽
                     </label>
                 </div>
 
                 <div class="form-group">
                     <label>Расстояние: <span id="distanceValue">10 км</span></label>
-                    <input type="range" id="distance" min="1" max="100" value="10" oninput="calculateAdvancedPrice()">
+                    <input type="range" id="distance" min="1" max="100" value="10">
                 </div>
 
                 <div class="price-result">
@@ -210,7 +210,7 @@
                         <div class="express-price" id="expressPrice" style="display: none;">Экспресс: <span>+500₽</span></div>
                         <div class="total">Итого: <span id="totalPrice">2500₽</span></div>
                     </div>
-                    <button class="btn btn-primary" onclick="ym(103201010,'reachGoal','tel_click'); openCallbackModal()">
+                    <button class="btn btn-primary" data-modal="callback" data-ym-goal="tel_click">
                         ЗАКАЗАТЬ ПО ЭТОЙ ЦЕНЕ
                     </button>
                 </div>
@@ -344,7 +344,7 @@
             <h2>Часто задаваемые вопросы</h2>
             <div class="faq-list">
                 <div class="faq-item">
-                    <div class="faq-question" onclick="toggleFaq(this)">
+                    <div class="faq-question">
                         <span>Сколько стоит эвакуация в Москве?</span>
                         <i class="fas fa-chevron-down"></i>
                     </div>
@@ -353,7 +353,7 @@
                     </div>
                 </div>
                 <div class="faq-item">
-                    <div class="faq-question" onclick="toggleFaq(this)">
+                    <div class="faq-question">
                         <span>Как быстро приедет эвакуатор?</span>
                         <i class="fas fa-chevron-down"></i>
                     </div>
@@ -362,7 +362,7 @@
                     </div>
                 </div>
                 <div class="faq-item">
-                    <div class="faq-question" onclick="toggleFaq(this)">
+                    <div class="faq-question">
                         <span>Какие способы оплаты принимаете?</span>
                         <i class="fas fa-chevron-down"></i>
                     </div>
@@ -371,7 +371,7 @@
                     </div>
                 </div>
                 <div class="faq-item">
-                    <div class="faq-question" onclick="toggleFaq(this)">
+                    <div class="faq-question">
                         <span>Есть ли страховка автомобиля?</span>
                         <i class="fas fa-chevron-down"></i>
                     </div>
@@ -418,7 +418,7 @@
                         <i class="fas fa-phone"></i>
                         +7 (977) 295-71-71
                     </a>
-                    <button class="btn btn-secondary btn-large" onclick="ym(103201010,'reachGoal','tel_click'); openCallbackModal()">
+                    <button class="btn btn-secondary btn-large" data-modal="callback" data-ym-goal="tel_click">
                         <i class="fas fa-callback"></i>
                         Перезвонить мне
                     </button>
@@ -474,16 +474,17 @@
     <!-- Callback Modal -->
     <div id="callbackModal" class="modal">
         <div class="modal-content">
-            <span class="close" onclick="closeCallbackModal()">&times;</span>
+            <button type="button" class="close" aria-label="Закрыть модальное окно">&times;</button>
             <h3>Заказать обратный звонок</h3>
             <p>Оставьте номер телефона и мы перезвоним в течение 30 секунд</p>
             <form id="callbackForm">
                 <input type="text" id="clientName" placeholder="Ваше имя" required>
                 <input type="tel" id="clientPhone" placeholder="+7 (___) ___-__-__" required>
-                <button type="submit" class="btn btn-primary" onclick="ym(103201010,'reachGoal','tel_click')">
+                <button type="submit" class="btn btn-primary" data-ym-goal="tel_click">
                     <i class="fas fa-phone"></i>
                     ПЕРЕЗВОНИТЬ МНЕ
                 </button>
+                <div class="form-feedback" id="callbackFeedback" role="status" aria-live="polite"></div>
             </form>
             <div class="callback-timer-container">
                 <div class="callback-timer-idle">


### PR DESCRIPTION
## Summary
- replace the legacy global scripts with an App controller that wires menu, calculator, FAQ, and modal behaviour and adds animated pricing updates driven by the selected options
- remove duplicated calculator utilities, introduce a reusable price computation routine, and add a callback service abstraction that can hit a backend endpoint or local stub
- clean up markup to rely on data attributes instead of inline handlers, add modal feedback messaging, and adjust styles for the new button- and message-based UI states

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cebd8d4a708324a05ec4a6b9cc65e8