### PR TITLE
Remove animation from floating call button

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -1418,7 +1418,6 @@ input[type="range"]::-webkit-slider-thumb {
     text-decoration: none;
     font-size: 1.5rem;
     box-shadow: 0 4px 20px rgba(255, 107, 53, 0.4);
-    animation: bounce 2s infinite;
 }
 
 .whatsapp-btn {


### PR DESCRIPTION
## Summary
- remove the bounce animation from the floating phone button so it remains stationary like the WhatsApp shortcut

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cec5fd63b48324b46f6a596f619e75